### PR TITLE
kategoriser arkivassistenter under "Musem, bibliotek, arkiv"

### DIFF
--- a/src/main/resources/styrk_category_mapping.csv
+++ b/src/main/resources/styrk_category_mapping.csv
@@ -225,7 +225,7 @@ Styrk code;Styrk description;Category level 1;Category level 2
 4411;Bibliotekassistenter;Kultur og kreative yrker;Museum, bibliotek, arkiv
 4412;Postbud og postsorterere;Salg og service;Post og måleavlesere
 4413;Kodere mv;Kontor og økonomi;Kontor, forvaltning og saksbehandling
-4415;Arkivassistenter;Kontor og økonomi;Kontor, forvaltning og saksbehandling
+4415;Arkivassistenter;Kultur og kreative yrker;Museum, bibliotek, arkiv
 4416;Personalkontormedarbeidere;Kontor og økonomi;Personal, arbeidsmiljø og rekruttering
 5111;Flyverter, båtverter mv.;Reiseliv og mat;Reiseliv, hotell og overnatting
 5112;Konduktører;Reiseliv og mat;Reiseliv, hotell og overnatting


### PR DESCRIPTION
Gjelder en tilbakemelding fra hotjar:

”Hei, dere bør kunne fange de samme stillingstypene med flere vanlige stikkord. Når jeg søker på arkivar får jeg opp 6 treff, men søker jeg kun på arkiv, så får jeg opp mange flere relevante stillinger, som er arkivar-stillinger. Søker jeg informasjonsforvaltning, får jeg noe, som gjelder også arkivarer, samme med dokumentsenter. Dere må finne en måte å koble vanlige yrkestitler med relevante stillinger. Ellers blir det en haug med ulike søk man må legge inn, for å fange opp alt som er relevant.”

Etter diskusjon så tenker vi at det er bedre med denne kategoriseringen